### PR TITLE
Modified the wrong file call in line 234 of nano_graphrag/graphrag.py

### DIFF
--- a/nano_graphrag/graphrag.py
+++ b/nano_graphrag/graphrag.py
@@ -231,7 +231,7 @@ class GraphRAG:
                     )
                 }
                 inserting_chunks.update(chunks)
-            _add_chunk_keys = await self.full_docs.filter_keys(
+            _add_chunk_keys = await self.text_chunks.filter_keys(
                 list(inserting_chunks.keys())
             )
             inserting_chunks = {


### PR DESCRIPTION
I found that chunks should be filtered here, because the documents have been filtered in line 211 of the code, and this line of operation is to operate on chunks.