### PR TITLE
Add HNSW vector storage

### DIFF
--- a/benchmarks/hnsw_vs_nano_vector_storage.py
+++ b/benchmarks/hnsw_vs_nano_vector_storage.py
@@ -1,0 +1,78 @@
+import asyncio
+import time
+import numpy as np
+from tqdm import tqdm
+from nano_graphrag import GraphRAG
+from nano_graphrag._storage import NanoVectorDBStorage, HNSWVectorStorage
+from nano_graphrag._utils import wrap_embedding_func_with_attrs
+
+
+WORKING_DIR = "./nano_graphrag_cache_benchmark_hnsw_vs_nano_vector_storage"
+DATA_LEN = 100_000
+FAKE_DIM = 1024
+BATCH_SIZE = 100000
+
+
+@wrap_embedding_func_with_attrs(embedding_dim=FAKE_DIM, max_token_size=8192)
+async def sample_embedding(texts: list[str]) -> np.ndarray:
+    return np.float32(np.random.rand(len(texts), FAKE_DIM))
+
+
+def generate_test_data():
+    return {str(i): {"content": f"Test content {i}"} for i in range(DATA_LEN)}
+
+
+async def benchmark_storage(storage_class, name):
+    rag = GraphRAG(working_dir=WORKING_DIR, embedding_func=sample_embedding)
+    storage = storage_class(
+        namespace=f"benchmark_{name}",
+        global_config=rag.__dict__,
+        embedding_func=sample_embedding,
+        meta_fields={"content"},
+    )
+
+    test_data = generate_test_data()
+    
+    print(f"Benchmarking {name}...")
+    with tqdm(total=DATA_LEN, desc=f"{name} Benchmark") as pbar:
+        start_time = time.time()
+        for i in range(0, len(test_data), BATCH_SIZE):
+            batch = {k: test_data[k] for k in list(test_data.keys())[i:i+BATCH_SIZE]}
+            await storage.upsert(batch)
+            pbar.update(min(BATCH_SIZE, DATA_LEN - i))
+        
+        insert_time = time.time() - start_time
+
+        save_start_time = time.time()
+        await storage.index_done_callback()
+        save_time = time.time() - save_start_time
+        pbar.update(1)
+
+        query_vector = np.random.rand(FAKE_DIM)
+        query_times = []
+        for _ in range(100):
+            query_start = time.time()
+            await storage.query(query_vector, top_k=10)
+            query_times.append(time.time() - query_start)
+            pbar.update(1)
+    
+    avg_query_time = sum(query_times) / len(query_times)
+    
+    print(f"{name} - Insert: {insert_time:.2f}s, Save: {save_time:.2f}s, Avg Query: {avg_query_time:.4f}s")
+    return insert_time, save_time, avg_query_time
+
+
+async def run_benchmarks():
+    print("Running NanoVectorDB benchmark...")
+    nano_insert_time, nano_save_time, nano_query_time = await benchmark_storage(NanoVectorDBStorage, "nano")
+    
+    print("\nRunning HNSWVectorStorage benchmark...")
+    hnsw_insert_time, hnsw_save_time, hnsw_query_time = await benchmark_storage(HNSWVectorStorage, "hnsw")
+    
+    print("\nBenchmark Results:")
+    print(f"NanoVectorDB - Insert: {nano_insert_time:.2f}s, Save: {nano_save_time:.2f}s, Avg Query: {nano_query_time:.4f}s")
+    print(f"HNSWVectorStorage - Insert: {hnsw_insert_time:.2f}s, Save: {hnsw_save_time:.2f}s, Avg Query: {hnsw_query_time:.4f}s")
+
+
+if __name__ == "__main__":
+    asyncio.run(run_benchmarks())

--- a/examples/using_hnsw_as_vectorDB.py
+++ b/examples/using_hnsw_as_vectorDB.py
@@ -1,5 +1,6 @@
 import os
 from nano_graphrag import GraphRAG, QueryParam
+from nano_graphrag._llm import gpt_4o_mini_complete
 from nano_graphrag._storage import HNSWVectorStorage
 
 
@@ -26,6 +27,11 @@ def insert():
         working_dir=WORKING_DIR,
         enable_llm_cache=True,
         vector_db_storage_cls=HNSWVectorStorage,
+        vector_db_storage_cls_kwargs={"max_elements": 1000000, "ef_search": 100, "M": 8},
+        best_model_max_async=1,
+        cheap_model_max_async=1,
+        best_model_func=gpt_4o_mini_complete,
+        cheap_model_func=gpt_4o_mini_complete,
     )
     start = time()
     rag.insert(FAKE_TEXT)
@@ -37,6 +43,11 @@ def query():
         working_dir=WORKING_DIR,
         enable_llm_cache=True,
         vector_db_storage_cls=HNSWVectorStorage,
+        vector_db_storage_cls_kwargs={"max_elements": 1000000, "ef_search": 100, "M": 8},
+        best_model_max_async=1,
+        cheap_model_max_async=1,
+        best_model_func=gpt_4o_mini_complete,
+        cheap_model_func=gpt_4o_mini_complete,
     )
     print(
         rag.query(

--- a/examples/using_hnsw_as_vectorDB.py
+++ b/examples/using_hnsw_as_vectorDB.py
@@ -1,0 +1,50 @@
+import os
+from nano_graphrag import GraphRAG, QueryParam
+from nano_graphrag._storage import HNSWVectorStorage
+
+
+WORKING_DIR = "./nano_graphrag_cache_using_hnsw_as_vectorDB"
+
+
+def remove_if_exist(file):
+    if os.path.exists(file):
+        os.remove(file)
+
+
+def insert():
+    from time import time
+
+    with open("./tests/mock_data.txt", encoding="utf-8-sig") as f:
+        FAKE_TEXT = f.read()
+
+    remove_if_exist(f"{WORKING_DIR}/vdb_entities.json")
+    remove_if_exist(f"{WORKING_DIR}/kv_store_full_docs.json")
+    remove_if_exist(f"{WORKING_DIR}/kv_store_text_chunks.json")
+    remove_if_exist(f"{WORKING_DIR}/kv_store_community_reports.json")
+    remove_if_exist(f"{WORKING_DIR}/graph_chunk_entity_relation.graphml")
+    rag = GraphRAG(
+        working_dir=WORKING_DIR,
+        enable_llm_cache=True,
+        vector_db_storage_cls=HNSWVectorStorage,
+    )
+    start = time()
+    rag.insert(FAKE_TEXT)
+    print("indexing time:", time() - start)
+
+
+def query():
+    rag = GraphRAG(
+        working_dir=WORKING_DIR,
+        enable_llm_cache=True,
+        vector_db_storage_cls=HNSWVectorStorage,
+    )
+    print(
+        rag.query(
+            "What are the top themes in this story?", param=QueryParam(mode="global")
+        )
+    )
+
+
+if __name__ == "__main__":
+    insert()
+    query()

--- a/nano_graphrag/_storage.py
+++ b/nano_graphrag/_storage.py
@@ -3,9 +3,10 @@ import html
 import json
 import os
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Union, cast
-
+import pickle
+import hnswlib
 import networkx as nx
 import numpy as np
 from nano_vectordb import NanoVectorDB
@@ -113,6 +114,102 @@ class NanoVectorDBStorage(BaseVectorStorage):
 
     async def index_done_callback(self):
         self._client.save()
+
+
+@dataclass
+class HNSWVectorStorage(BaseVectorStorage):
+    ef_construction: int = 100
+    M: int = 16
+    max_elements: int = 1000000
+    num_threads: int = -1
+    _index: Any = field(init=False)
+    _metadata: dict[str, dict] = field(default_factory=dict)
+    _current_elements: int = 0
+
+    def __post_init__(self):
+        self._index_file_name = os.path.join(
+            self.global_config["working_dir"], f"{self.namespace}_hnsw.index"
+        )
+        self._metadata_file_name = os.path.join(
+            self.global_config["working_dir"], f"{self.namespace}_hnsw_metadata.pkl"
+        )
+        self._max_batch_size = self.global_config.get("embedding_batch_num", 100)
+
+        if os.path.exists(self._index_file_name) and os.path.exists(self._metadata_file_name):
+            self._index = hnswlib.Index(space='cosine', dim=self.embedding_func.embedding_dim)
+            self._index.load_index(self._index_file_name, max_elements=self.max_elements)
+            with open(self._metadata_file_name, 'rb') as f:
+                self._metadata, self._current_elements = pickle.load(f)
+            logger.info(f"Loaded existing index for {self.namespace} with {self._current_elements} elements")
+        else:
+            self._index = hnswlib.Index(space='cosine', dim=self.embedding_func.embedding_dim)
+            self._index.init_index(
+                max_elements=self.max_elements,
+                ef_construction=self.ef_construction,
+                M=self.M
+            )
+            logger.info(f"Created new index for {self.namespace}")
+
+    async def upsert(self, data: dict[str, dict]):
+        logger.info(f"Inserting {len(data)} vectors to {self.namespace}")
+        if not data:
+            raise ValueError("Attempting to insert empty data to vector DB")
+
+        if self._current_elements + len(data) > self.max_elements:
+            raise ValueError(f"Cannot insert {len(data)} elements. Current: {self._current_elements}, Max: {self.max_elements}")
+
+        contents = [v["content"] for v in data.values()]
+        batches = [
+            contents[i : i + self._max_batch_size]
+            for i in range(0, len(contents), self._max_batch_size)
+        ]
+        embeddings_list = await asyncio.gather(
+            *[self.embedding_func(batch) for batch in batches]
+        )
+        embeddings = np.concatenate(embeddings_list)
+
+        ids = []
+        for id, item in data.items():
+            metadata = {k: v for k, v in item.items() if k in self.meta_fields}
+            metadata['id'] = id
+            self._metadata[id] = metadata
+            ids.append(int(id) if id.isdigit() else hash(id))
+
+        ids = np.array(ids)
+        self._index.add_items(data=embeddings, ids=ids, num_threads=self.num_threads)
+        self._current_elements += len(data)
+
+    async def query(self, query: str, top_k: int = 5, ef_search: int = 50) -> list[dict]:
+        if len(self._metadata) == 0:
+            return []
+        
+        if top_k >= ef_search:
+            raise ValueError(f"top_k must be greater than or equal to ef_search, got {top_k} and {ef_search}")
+        
+        self._index.set_ef(ef_search)
+        query_vector = await self.embedding_func([query])
+        labels, distances = self._index.knn_query(
+            data=query_vector, 
+            k=min(top_k, len(self._metadata)), 
+            num_threads=self.num_threads
+        )
+        
+        results = []
+        for label, distance in zip(labels[0], distances[0]):
+            id_str = str(label)
+            if id_str in self._metadata:
+                metadata = self._metadata[id_str]
+                results.append({
+                    **metadata,
+                    "distance": distance,
+                    "similarity": 1 - distance
+                })
+        return results
+
+    async def index_done_callback(self):
+        self._index.save_index(self._index_file_name)
+        with open(self._metadata_file_name, 'wb') as f:
+            pickle.dump((self._metadata, self._current_elements), f)
 
 
 @dataclass

--- a/nano_graphrag/graphrag.py
+++ b/nano_graphrag/graphrag.py
@@ -104,6 +104,7 @@ class GraphRAG:
     # storage
     key_string_value_json_storage_cls: Type[BaseKVStorage] = JsonKVStorage
     vector_db_storage_cls: Type[BaseVectorStorage] = NanoVectorDBStorage
+    vector_db_storage_cls_kwargs: dict = field(default_factory=dict)
     graph_storage_cls: Type[BaseGraphStorage] = NetworkXStorage
     enable_llm_cache: bool = True
 
@@ -151,6 +152,7 @@ class GraphRAG:
                 global_config=asdict(self),
                 embedding_func=self.embedding_func,
                 meta_fields={"entity_name"},
+                **self.vector_db_storage_cls_kwargs,
             )
             if self.enable_local
             else None

--- a/nano_graphrag/graphrag.py
+++ b/nano_graphrag/graphrag.py
@@ -151,8 +151,7 @@ class GraphRAG:
                 namespace="entities",
                 global_config=asdict(self),
                 embedding_func=self.embedding_func,
-                meta_fields={"entity_name"},
-                **self.vector_db_storage_cls_kwargs,
+                meta_fields={"entity_name"}
             )
             if self.enable_local
             else None

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ tiktoken
 networkx
 graspologic
 nano-vectordb
+hnswlib

--- a/tests/test_hnsw_vector_storage.py
+++ b/tests/test_hnsw_vector_storage.py
@@ -1,0 +1,191 @@
+import os
+import shutil
+import numpy as np
+import pytest
+from unittest.mock import patch
+from dataclasses import asdict
+from nano_graphrag import GraphRAG
+from nano_graphrag._utils import wrap_embedding_func_with_attrs
+from nano_graphrag._storage import HNSWVectorStorage
+
+WORKING_DIR = "./tests/nano_graphrag_cache_HNSW_TEST"
+
+
+@pytest.fixture(scope="function")
+def setup_teardown():
+    if os.path.exists(WORKING_DIR):
+        shutil.rmtree(WORKING_DIR)
+    os.mkdir(WORKING_DIR)
+    
+    yield
+    
+    shutil.rmtree(WORKING_DIR)
+
+
+@wrap_embedding_func_with_attrs(embedding_dim=384, max_token_size=8192)
+async def mock_embedding(texts: list[str]) -> np.ndarray:
+    return np.random.rand(len(texts), 384)
+
+
+@pytest.fixture
+def hnsw_storage(setup_teardown):
+    rag = GraphRAG(working_dir=WORKING_DIR, embedding_func=mock_embedding)
+    return HNSWVectorStorage(
+        namespace="test",
+        global_config=asdict(rag),
+        embedding_func=mock_embedding,
+        meta_fields={"entity_name"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_query(hnsw_storage):
+    test_data = {
+        "1": {"content": "Test content 1", "entity_name": "Entity 1"},
+        "2": {"content": "Test content 2", "entity_name": "Entity 2"},
+    }
+    
+    await hnsw_storage.upsert(test_data)
+    
+    results = await hnsw_storage.query("Test query", top_k=2)
+    
+    assert len(results) == 2
+    assert all(isinstance(result, dict) for result in results)
+    assert all("id" in result and "distance" in result and "similarity" in result for result in results)
+
+
+@pytest.mark.asyncio
+async def test_persistence(setup_teardown):
+    rag = GraphRAG(working_dir=WORKING_DIR, embedding_func=mock_embedding)
+    initial_storage = HNSWVectorStorage(
+        namespace="test",
+        global_config=asdict(rag),
+        embedding_func=mock_embedding,
+        meta_fields={"entity_name"}
+    )
+    
+    test_data = {
+        "1": {"content": "Test content 1", "entity_name": "Entity 1"},
+    }
+    
+    await initial_storage.upsert(test_data)
+    await initial_storage.index_done_callback()
+    
+    new_storage = HNSWVectorStorage(
+        namespace="test",
+        global_config=asdict(rag),
+        embedding_func=mock_embedding,
+        meta_fields={"entity_name"}
+    )
+    
+    results = await new_storage.query("Test query", top_k=1)
+    
+    assert len(results) == 1
+    assert results[0]["id"] == "1"
+    assert "entity_name" in results[0]
+
+
+@pytest.mark.asyncio
+async def test_empty_upsert(hnsw_storage):
+    with pytest.raises(ValueError):
+        await hnsw_storage.upsert({})
+
+
+@pytest.mark.asyncio
+async def test_upsert_with_existing_ids(hnsw_storage):
+    test_data = {
+        "1": {"content": "Test content 1", "entity_name": "Entity 1"},
+        "2": {"content": "Test content 2", "entity_name": "Entity 2"},
+    }
+    
+    await hnsw_storage.upsert(test_data)
+    
+    updated_data = {
+        "1": {"content": "Updated content 1", "entity_name": "Updated Entity 1"},
+        "3": {"content": "Test content 3", "entity_name": "Entity 3"},
+    }
+    
+    await hnsw_storage.upsert(updated_data)
+    
+    results = await hnsw_storage.query("Updated", top_k=3)
+    assert len(results) == 3
+    assert any(result["id"] == "1" and result["entity_name"] == "Updated Entity 1" for result in results)
+    assert any(result["id"] == "3" for result in results)
+
+
+@pytest.mark.asyncio
+async def test_large_batch_upsert(hnsw_storage):
+    batch_size = 30
+    large_data = {str(i): {"content": f"Test content {i}", "entity_name": f"Entity {i}"} for i in range(batch_size)}
+    
+    await hnsw_storage.upsert(large_data)
+    
+    results = await hnsw_storage.query("Test query", top_k=batch_size)
+    assert len(results) == batch_size
+    assert all(isinstance(result, dict) for result in results)
+    assert all("id" in result and "distance" in result and "similarity" in result for result in results)
+
+
+@pytest.mark.asyncio
+async def test_query_with_no_results(hnsw_storage):
+    results = await hnsw_storage.query("Non-existent query", top_k=5)
+    assert len(results) == 0
+
+    test_data = {
+        "1": {"content": "Test content 1", "entity_name": "Entity 1"},
+    }
+    await hnsw_storage.upsert(test_data)
+
+    results = await hnsw_storage.query("Non-existent query", top_k=5)
+    assert len(results) == 1
+    assert all(0 <= result["similarity"] <= 1 for result in results)
+    assert "entity_name" in results[0]
+
+
+@pytest.mark.asyncio
+async def test_index_done_callback(hnsw_storage):
+    test_data = {
+        "1": {"content": "Test content 1", "entity_name": "Entity 1"},
+    }
+    
+    await hnsw_storage.upsert(test_data)
+    
+    with patch('hnswlib.Index.save_index') as mock_save_index:
+        await hnsw_storage.index_done_callback()
+        mock_save_index.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_max_elements_limit(setup_teardown):
+    rag = GraphRAG(working_dir=WORKING_DIR, embedding_func=mock_embedding)
+    max_elements = 10
+    small_storage = HNSWVectorStorage(
+        namespace="test_small",
+        global_config=asdict(rag),
+        embedding_func=mock_embedding,
+        meta_fields={"entity_name"},
+        max_elements=max_elements
+    )
+
+    data = {str(i): {"content": f"Test content {i}", "entity_name": f"Entity {i}"} for i in range(max_elements)}
+    await small_storage.upsert(data)
+
+    with pytest.raises(ValueError, match=f"Cannot insert 1 elements. Current: {max_elements}, Max: {max_elements}"):
+        await small_storage.upsert({str(max_elements): {"content": "Overflow", "entity_name": "Overflow Entity"}})
+
+    large_max_elements = 100
+    large_storage = HNSWVectorStorage(
+        namespace="test_large",
+        global_config=asdict(rag),
+        embedding_func=mock_embedding,
+        meta_fields={"entity_name"},
+        max_elements=large_max_elements
+    )
+
+    initial_data_size = int(large_max_elements * 0.3)
+    initial_data = {str(i): {"content": f"Test content {i}", "entity_name": f"Entity {i}"} for i in range(initial_data_size)}
+    
+    await large_storage.upsert(initial_data)
+
+    results = await large_storage.query("Test query", top_k=initial_data_size)
+    assert len(results) == initial_data_size


### PR DESCRIPTION
# Description

TLDR; fast querying with slow insertion, using `hnswlib` faster than the HNSW from `faiss` implementation.

# Updates

- [x] Added `HNSWVectorDBStorage`.
- [x] Added basic unit tests.
- [x] Added basic benchmarking against `NanoVectorDBStorage`.
- [x] Added an example under `examples` with `GraphRAG` (Easily triggering rate limit but unrelated to this PR).

# Benchmark results
```shell
> python benchmarks/hnsw_vs_nano_vector_storage.py 
Running NanoVectorDB benchmark...
INFO:nano-graphrag:Creating working directory ./nano_graphrag_cache_benchmark_hnsw_vs_nano_vector_storage
INFO:nano-graphrag:Load KV full_docs with 0 data
INFO:nano-graphrag:Load KV text_chunks with 0 data
INFO:nano-graphrag:Load KV llm_response_cache with 0 data
INFO:nano-graphrag:Load KV community_reports with 0 data
INFO:nano-vectordb:Init {'embedding_dim': 1024, 'metric': 'cosine', 'storage_file': './nano_graphrag_cache_benchmark_hnsw_vs_nano_vector_storage/vdb_entities.json'} 0 data
INFO:nano-vectordb:Init {'embedding_dim': 1024, 'metric': 'cosine', 'storage_file': './nano_graphrag_cache_benchmark_hnsw_vs_nano_vector_storage/vdb_benchmark_nano.json'} 0 data
Benchmarking nano...
nano Benchmark:   0%|                                                                                                                                                                                                      | 0/100000 [00:00<?, ?it/s]INFO:nano-graphrag:Inserting 100000 vectors to benchmark_nano
nano Benchmark: 100101it [00:04, 22470.39it/s]                                                                                                                                                                                                        
nano - Insert: 1.44s, Save: 1.81s, Avg Query: 0.0120s

Running HNSWVectorStorage benchmark...
INFO:nano-graphrag:Load KV full_docs with 0 data
INFO:nano-graphrag:Load KV text_chunks with 0 data
INFO:nano-graphrag:Load KV llm_response_cache with 0 data
INFO:nano-graphrag:Load KV community_reports with 0 data
INFO:nano-vectordb:Init {'embedding_dim': 1024, 'metric': 'cosine', 'storage_file': './nano_graphrag_cache_benchmark_hnsw_vs_nano_vector_storage/vdb_entities.json'} 0 data
INFO:nano-graphrag:Created new index for benchmark_hnsw
Benchmarking hnsw...
hnsw Benchmark:   0%|                                                                                                                                                                                                      | 0/100000 [00:00<?, ?it/s]INFO:nano-graphrag:Inserting 100000 vectors to benchmark_hnsw
hnsw Benchmark: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████hnsw Benchmark: 100101it [01:24, 1187.70it/s]                                                                                                                                                                                                         
hnsw - Insert: 83.67s, Save: 0.44s, Avg Query: 0.0017s

Benchmark Results:
NanoVectorDB - Insert: 1.44s, Save: 1.81s, Avg Query: 0.0120s
HNSWVectorStorage - Insert: 83.67s, Save: 0.44s, Avg Query: 0.0017s
```