### PR TITLE
entity extraction失败可能是由过小的num_ctx引起的, 给出了一种解决办法

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -35,6 +35,7 @@ Solution:
   Add a new line into this file below the 'FROM':
   
   `PARAMETER num_ctx 32000`
+  
   `ollama create -f Modelfile qwen2:ctx32k`
   
   Afterwards, you can use qwen2:ctx32k to replace qwen2.

--- a/FAQ.md
+++ b/FAQ.md
@@ -21,3 +21,20 @@ Try to use another bigger LLM, or here are some ideas to fix it:
     ```
     You can use this system_prompt as default for your LLM calling funcation
     
+
+### One possible reason of 'Processed 42 chunks,0 entities(duplicated),0 relations(duplicated)WARNING:nano-graphrag:Didn't extract any entities, maybe your LLM is not working WARNING:nano-graphrag:No new entities found'
+
+The default num_ctx of ollama is 2048 which is too small for the input prompt of entity extraction. This causes the model to fail to respond correctly. 
+
+Solution:
+  Each model in Ollama has a configuration file. Here, you need to generate a new configuration file based on the original one, and then use this configuration file to generate a new model.
+  For example the qwen2, run the following command:
+  
+  `ollama show --modelfile qwen2 > Modelfile`
+  
+  Add a new line into this file below the 'FROM':
+  
+  `PARAMETER num_ctx 32000`
+  `ollama create -f Modelfile qwen2:ctx32k`
+  
+  Afterwards, you can use qwen2:ctx32k to replace qwen2.


### PR DESCRIPTION
One possible reason of 'Processed 42 chunks,0 entities(duplicated),0 relations(duplicated)WARNING:nano-graphrag:Didn't extract any entities, maybe your LLM is not working WARNING:nano-graphrag:No new entities found'