### PR TITLE
Add project repo that used nano

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -405,6 +405,7 @@ See [ROADMAP.md](./docs/ROADMAP.md)
 - [Medical Graph RAG](https://github.com/MedicineToken/Medical-Graph-RAG): Graph RAG for the Medical Data
 - [LightRAG](https://github.com/HKUDS/LightRAG): Simple and Fast Retrieval-Augmented Generation
 - [fast-graphrag](https://github.com/circlemind-ai/fast-graphrag): RAG that intelligently adapts to your use case, data, and queries
+- [HiRAG](https://github.com/hhy-huang/HiRAG): Retrieval-Augmented Generation with Hierarchical Knowledge
 
 > Welcome to pull requests if your project uses `nano-graphrag`, it will help others to trust this repo❤️
 


### PR DESCRIPTION
Our work HiRAG(https://github.com/hhy-huang/HiRAG) is based on the code structure of nano-graphrag