### PR TITLE
Supporting for faster batch search and storage

### DIFF
--- a/nano_graphrag/_storage/gdb_neo4j.py
+++ b/nano_graphrag/_storage/gdb_neo4j.py
@@ -1,6 +1,7 @@
 import json
 import asyncio
 from collections import defaultdict
+from typing import List
 from neo4j import AsyncGraphDatabase
 from dataclasses import dataclass
 from typing import Union
@@ -12,7 +13,7 @@ neo4j_lock = asyncio.Lock()
 
 
 def make_path_idable(path):
-    return path.replace(".", "_").replace("/", "__").replace("-", "_").replace(":", "_")
+    return path.replace(".", "_").replace("/", "__").replace("-", "_").replace(":", "_").replace("\\", "__")
 
 
 @dataclass
@@ -27,7 +28,7 @@ class Neo4jStorage(BaseGraphStorage):
         if self.neo4j_url is None or self.neo4j_auth is None:
             raise ValueError("Missing neo4j_url or neo4j_auth in addon_params")
         self.async_driver = AsyncGraphDatabase.driver(
-            self.neo4j_url, auth=self.neo4j_auth
+            self.neo4j_url, auth=self.neo4j_auth, max_connection_pool_size=50,      
         )
 
     # async def create_database(self):
@@ -65,6 +66,29 @@ class Neo4jStorage(BaseGraphStorage):
     async def index_start_callback(self):
         logger.info("Init Neo4j workspace")
         await self._init_workspace()
+        
+        # create index for faster searching
+        try:
+            async with self.async_driver.session() as session:
+                await session.run(
+                    f"CREATE INDEX IF NOT EXISTS FOR (n:`{self.namespace}`) ON (n.id)"
+                )
+                
+                await session.run(
+                    f"CREATE INDEX IF NOT EXISTS FOR (n:`{self.namespace}`) ON (n.entity_type)"
+                )
+                
+                await session.run(
+                    f"CREATE INDEX IF NOT EXISTS FOR (n:`{self.namespace}`) ON (n.communityIds)"
+                )
+                
+                await session.run(
+                    f"CREATE INDEX IF NOT EXISTS FOR (n:`{self.namespace}`) ON (n.source_id)"
+                )          
+                logger.info("Neo4j indexes created successfully")                
+        except Exception as e:
+            logger.error(f"Failed to create indexes: {e}")
+            raise e
 
     async def has_node(self, node_id: str) -> bool:
         async with self.async_driver.session() as session:
@@ -78,112 +102,287 @@ class Neo4jStorage(BaseGraphStorage):
     async def has_edge(self, source_node_id: str, target_node_id: str) -> bool:
         async with self.async_driver.session() as session:
             result = await session.run(
-                f"MATCH (s:`{self.namespace}`)-[r]->(t:`{self.namespace}`) "
-                "WHERE s.id = $source_id AND t.id = $target_id "
-                "RETURN COUNT(r) > 0 AS exists",
+                f"""
+                MATCH (s:`{self.namespace}`)
+                WHERE s.id = $source_id
+                MATCH (t:`{self.namespace}`)
+                WHERE t.id = $target_id
+                RETURN EXISTS((s)-[]->(t)) AS exists
+                """,
                 source_id=source_node_id,
                 target_id=target_node_id,
             )
+    
             record = await result.single()
             return record["exists"] if record else False
 
     async def node_degree(self, node_id: str) -> int:
+        results = await self.node_degrees_batch([node_id])
+        return results[0] if results else 0
+        
+    async def node_degrees_batch(self, node_ids: List[str]) -> List[str]:
+        if not node_ids:
+            return {}
+                    
+        result_dict = {node_id: 0 for node_id in node_ids}
         async with self.async_driver.session() as session:
             result = await session.run(
-                f"MATCH (n:`{self.namespace}`) WHERE n.id = $node_id "
-                f"RETURN COUNT {{(n)-[]-(:`{self.namespace}`)}} AS degree",
-                node_id=node_id,
+                f"""
+                UNWIND $node_ids AS node_id
+                MATCH (n:`{self.namespace}`)
+                WHERE n.id = node_id
+                OPTIONAL MATCH (n)-[]-(m:`{self.namespace}`)
+                RETURN node_id, COUNT(m) AS degree
+                """,
+                node_ids=node_ids
             )
-            record = await result.single()
-            return record["degree"] if record else 0
-
+                
+            async for record in result:
+                result_dict[record["node_id"]] = record["degree"]
+                
+        return [result_dict[node_id] for node_id in node_ids]
+    
     async def edge_degree(self, src_id: str, tgt_id: str) -> int:
-        async with self.async_driver.session() as session:
-            result = await session.run(
-                f"MATCH (s:`{self.namespace}`), (t:`{self.namespace}`) "
-                "WHERE s.id = $src_id AND t.id = $tgt_id "
-                f"RETURN COUNT {{(s)-[]-(:`{self.namespace}`)}} + COUNT {{(t)-[]-(:`{self.namespace}`)}} AS degree",
-                src_id=src_id,
-                tgt_id=tgt_id,
-            )
-            record = await result.single()
-            return record["degree"] if record else 0
+        results = await self.edge_degrees_batch([(src_id, tgt_id)])
+        return results[0] if results else 0
+
+    async def edge_degrees_batch(self, edge_pairs: list[tuple[str, str]]) -> list[int]:
+        if not edge_pairs:
+            return []
+        
+        result_dict = {tuple(edge_pair): 0 for edge_pair in edge_pairs}
+        
+        edges_params = [{"src_id": src, "tgt_id": tgt} for src, tgt in edge_pairs]
+        
+        try:
+            async with self.async_driver.session() as session:
+                result = await session.run(
+                    f"""
+                    UNWIND $edges AS edge
+                    
+                    MATCH (s:`{self.namespace}`)
+                    WHERE s.id = edge.src_id
+                    WITH edge, s
+                    OPTIONAL MATCH (s)-[]-(n1:`{self.namespace}`)
+                    WITH edge, COUNT(n1) AS src_degree
+                    
+                    MATCH (t:`{self.namespace}`)
+                    WHERE t.id = edge.tgt_id
+                    WITH edge, src_degree, t
+                    OPTIONAL MATCH (t)-[]-(n2:`{self.namespace}`)
+                    WITH edge.src_id AS src_id, edge.tgt_id AS tgt_id, src_degree, COUNT(n2) AS tgt_degree
+                    
+                    RETURN src_id, tgt_id, src_degree + tgt_degree AS degree
+                    """,
+                    edges=edges_params
+                )
+                
+                async for record in result:
+                    src_id = record["src_id"]
+                    tgt_id = record["tgt_id"]
+                    degree = record["degree"]
+                    
+                    # 更新结果字典
+                    edge_pair = (src_id, tgt_id)
+                    result_dict[edge_pair] = degree
+            
+            return [result_dict[tuple(edge_pair)] for edge_pair in edge_pairs]
+        except Exception as e:
+            logger.error(f"Error in batch edge degree calculation: {e}")
+            return [0] * len(edge_pairs)
+
+
 
     async def get_node(self, node_id: str) -> Union[dict, None]:
-        async with self.async_driver.session() as session:
-            result = await session.run(
-                f"MATCH (n:`{self.namespace}`) WHERE n.id = $node_id RETURN properties(n) AS node_data",
-                node_id=node_id,
-            )
-            record = await result.single()
-            raw_node_data = record["node_data"] if record else None
-        if raw_node_data is None:
-            return None
-        raw_node_data["clusters"] = json.dumps(
-            [
-                {
-                    "level": index,
-                    "cluster": cluster_id,
-                }
-                for index, cluster_id in enumerate(
-                    raw_node_data.get("communityIds", [])
+        result = await self.get_nodes_batch([node_id])
+        return result[0] if result else None
+
+    async def get_nodes_batch(self, node_ids: list[str]) -> dict[str, Union[dict, None]]:
+        if not node_ids:
+            return {}
+            
+        result_dict = {node_id: None for node_id in node_ids}
+
+        try:
+            async with self.async_driver.session() as session:
+                result = await session.run(
+                    f"""
+                    UNWIND $node_ids AS node_id
+                    MATCH (n:`{self.namespace}`)
+                    WHERE n.id = node_id
+                    RETURN node_id, properties(n) AS node_data
+                    """,
+                    node_ids=node_ids
                 )
-            ]
-        )
-        return raw_node_data
+                
+                async for record in result:
+                    node_id = record["node_id"]
+                    raw_node_data = record["node_data"]
+                    
+                    if raw_node_data:
+                        raw_node_data["clusters"] = json.dumps(
+                            [
+                                {
+                                    "level": index,
+                                    "cluster": cluster_id,
+                                }
+                                for index, cluster_id in enumerate(
+                                    raw_node_data.get("communityIds", [])
+                                )
+                            ]
+                        )
+                        result_dict[node_id] = raw_node_data
+            return [result_dict[node_id] for node_id in node_ids]
+        except Exception as e:
+            logger.error(f"Error in batch node retrieval: {e}")
+            raise e
 
     async def get_edge(
         self, source_node_id: str, target_node_id: str
     ) -> Union[dict, None]:
-        async with self.async_driver.session() as session:
-            result = await session.run(
-                f"MATCH (s:`{self.namespace}`)-[r]->(t:`{self.namespace}`) "
-                "WHERE s.id = $source_id AND t.id = $target_id "
-                "RETURN properties(r) AS edge_data",
-                source_id=source_node_id,
-                target_id=target_node_id,
-            )
-            record = await result.single()
-            return record["edge_data"] if record else None
+        results = await self.get_edges_batch([(source_node_id, target_node_id)])
+        return results[0] if results else None
+
+    async def get_edges_batch(
+        self, edge_pairs: list[tuple[str, str]]
+    ) -> list[Union[dict, None]]:
+        if not edge_pairs:
+            return []
+            
+        result_dict = {tuple(edge_pair): None for edge_pair in edge_pairs}
+        
+        edges_params = [{"source_id": src, "target_id": tgt} for src, tgt in edge_pairs]
+        
+        try:
+            async with self.async_driver.session() as session:
+                result = await session.run(
+                    f"""
+                    UNWIND $edges AS edge
+                    MATCH (s:`{self.namespace}`)-[r]->(t:`{self.namespace}`)
+                    WHERE s.id = edge.source_id AND t.id = edge.target_id
+                    RETURN edge.source_id AS source_id, edge.target_id AS target_id, properties(r) AS edge_data
+                    """,
+                    edges=edges_params
+                )
+                
+                async for record in result:
+                    source_id = record["source_id"]
+                    target_id = record["target_id"]
+                    edge_data = record["edge_data"]
+                    
+                    edge_pair = (source_id, target_id)
+                    result_dict[edge_pair] = edge_data
+            
+            return [result_dict[tuple(edge_pair)] for edge_pair in edge_pairs]
+        except Exception as e:
+            logger.error(f"Error in batch edge retrieval: {e}")
+            return [None] * len(edge_pairs)
 
     async def get_node_edges(
         self, source_node_id: str
-    ) -> Union[list[tuple[str, str]], None]:
-        async with self.async_driver.session() as session:
-            result = await session.run(
-                f"MATCH (s:`{self.namespace}`)-[r]->(t:`{self.namespace}`) WHERE s.id = $source_id "
-                "RETURN s.id AS source, t.id AS target",
-                source_id=source_node_id,
-            )
-            edges = []
-            async for record in result:
-                edges.append((record["source"], record["target"]))
-            return edges
+    ) -> list[tuple[str, str]]:
+        results = await self.get_nodes_edges_batch([source_node_id])
+        return results[0] if results else []
+
+    async def get_nodes_edges_batch(
+        self, node_ids: list[str]
+    ) -> list[list[tuple[str, str]]]:
+        if not node_ids:
+            return []
+            
+        result_dict = {node_id: [] for node_id in node_ids}
+        
+        try:
+            async with self.async_driver.session() as session:
+                result = await session.run(
+                    f"""
+                    UNWIND $node_ids AS node_id
+                    MATCH (s:`{self.namespace}`)-[r]->(t:`{self.namespace}`)
+                    WHERE s.id = node_id
+                    RETURN s.id AS source_id, t.id AS target_id
+                    """,
+                    node_ids=node_ids
+                )
+                
+                async for record in result:
+                    source_id = record["source_id"]
+                    target_id = record["target_id"]
+                    
+                    if source_id in result_dict:
+                        result_dict[source_id].append((source_id, target_id))
+            
+            return [result_dict[node_id] for node_id in node_ids]
+        except Exception as e:
+            logger.error(f"Error in batch node edges retrieval: {e}")
+            return [[] for _ in node_ids]
 
     async def upsert_node(self, node_id: str, node_data: dict[str, str]):
-        node_type = node_data.get("entity_type", "UNKNOWN").strip('"')
-        async with self.async_driver.session() as session:
-            await session.run(
-                f"MERGE (n:`{self.namespace}`:`{node_type}` {{id: $node_id}}) "
-                "SET n += $node_data",
-                node_id=node_id,
-                node_data=node_data,
-            )
+        await self.upsert_nodes_batch([(node_id, node_data)])
 
+    async def upsert_nodes_batch(self, nodes_data: list[tuple[str, dict[str, str]]]):
+        if not nodes_data:
+            return []
+        
+        nodes_by_type = {}
+        for node_id, node_data in nodes_data:
+            node_type = node_data.get("entity_type", "UNKNOWN").strip('"')
+            if node_type not in nodes_by_type:
+                nodes_by_type[node_type] = []
+            nodes_by_type[node_type].append((node_id, node_data))
+        
+        async with self.async_driver.session() as session:
+            for node_type, type_nodes in nodes_by_type.items():
+                params = [{"id": node_id, "data": node_data} for node_id, node_data in type_nodes]
+                
+                await session.run(
+                    f"""
+                    UNWIND $nodes AS node
+                    MERGE (n:`{self.namespace}`:`{node_type}` {{id: node.id}})
+                    SET n += node.data
+                    """,
+                    nodes=params
+                )
+        
     async def upsert_edge(
         self, source_node_id: str, target_node_id: str, edge_data: dict[str, str]
     ):
-        edge_data.setdefault("weight", 0.0)
+        await self.upsert_edges_batch([(source_node_id, target_node_id, edge_data)])
+
+
+    async def upsert_edges_batch(
+        self, edges_data: list[tuple[str, str, dict[str, str]]]
+    ):
+        if not edges_data:
+            return
+        
+        edges_params = []
+        for source_id, target_id, edge_data in edges_data:
+            edge_data_copy = edge_data.copy() 
+            edge_data_copy.setdefault("weight", 0.0)
+            
+            edges_params.append({
+                "source_id": source_id,
+                "target_id": target_id,
+                "edge_data": edge_data_copy
+            })
+        
         async with self.async_driver.session() as session:
             await session.run(
-                f"MATCH (s:`{self.namespace}`), (t:`{self.namespace}`) "
-                "WHERE s.id = $source_id AND t.id = $target_id "
-                "MERGE (s)-[r:RELATED]->(t) "  # Added relationship type 'RELATED'
-                "SET r += $edge_data",
-                source_id=source_node_id,
-                target_id=target_node_id,
-                edge_data=edge_data,
+                f"""
+                UNWIND $edges AS edge
+                MATCH (s:`{self.namespace}`)
+                WHERE s.id = edge.source_id
+                WITH edge, s
+                MATCH (t:`{self.namespace}`)
+                WHERE t.id = edge.target_id
+                MERGE (s)-[r:RELATED]->(t)
+                SET r += edge.edge_data
+                """,
+                edges=edges_params
             )
+        
+
+
 
     async def clustering(self, algorithm: str):
         if algorithm != "leiden":

--- a/nano_graphrag/_utils.py
+++ b/nano_graphrag/_utils.py
@@ -14,6 +14,7 @@ import numpy as np
 import tiktoken
 
 logger = logging.getLogger("nano-graphrag")
+logging.getLogger("neo4j").setLevel(logging.ERROR)
 ENCODER = None
 
 def always_get_an_event_loop() -> asyncio.AbstractEventLoop:

--- a/nano_graphrag/base.py
+++ b/nano_graphrag/base.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import TypedDict, Union, Literal, Generic, TypeVar
+from typing import TypedDict, Union, Literal, Generic, TypeVar, List
 
 import numpy as np
 
@@ -123,11 +123,20 @@ class BaseGraphStorage(StorageNameSpace):
 
     async def node_degree(self, node_id: str) -> int:
         raise NotImplementedError
+    
+    async def node_degrees_batch(self, node_ids: List[str]) -> List[str]:
+        raise NotImplementedError
 
     async def edge_degree(self, src_id: str, tgt_id: str) -> int:
         raise NotImplementedError
 
+    async def edge_degrees_batch(self, edge_pairs: list[tuple[str, str]]) -> list[int]:
+        raise NotImplementedError
+
     async def get_node(self, node_id: str) -> Union[dict, None]:
+        raise NotImplementedError
+
+    async def get_nodes_batch(self, node_ids: list[str]) -> dict[str, Union[dict, None]]:
         raise NotImplementedError
 
     async def get_edge(
@@ -135,16 +144,34 @@ class BaseGraphStorage(StorageNameSpace):
     ) -> Union[dict, None]:
         raise NotImplementedError
 
+    async def get_edges_batch(
+        self, edge_pairs: list[tuple[str, str]]
+    ) -> list[Union[dict, None]]:
+        raise NotImplementedError
+
     async def get_node_edges(
         self, source_node_id: str
     ) -> Union[list[tuple[str, str]], None]:
         raise NotImplementedError
 
+    async def get_nodes_edges_batch(
+        self, node_ids: list[str]
+    ) -> list[list[tuple[str, str]]]:
+        raise NotImplementedError
+
     async def upsert_node(self, node_id: str, node_data: dict[str, str]):
+        raise NotImplementedError
+
+    async def upsert_nodes_batch(self, nodes_data: list[tuple[str, dict[str, str]]]):
         raise NotImplementedError
 
     async def upsert_edge(
         self, source_node_id: str, target_node_id: str, edge_data: dict[str, str]
+    ):
+        raise NotImplementedError
+
+    async def upsert_edges_batch(
+        self, edges_data: list[tuple[str, str, dict[str, str]]]
     ):
         raise NotImplementedError
 


### PR DESCRIPTION
When using Neo4j to store graphs, the original code creates a new session asynchronously for each query on the nodes, edges, and their degrees in the graph. This means that every operation on each node creates a new session. In practice, it was found that when Python asynchronously calls Neo4j, all asynchronous functions are executed first and then returned in bulk. As a result, when the session coroutine pool is large, the interaction process becomes very slow. This mechanism causes the project to interact very slowly with the database when dealing with a large number of graph nodes.

In fact, Neo4j supports batch operations on graph nodes and edges--Just like what we tend to do in Machine Learning. Therefore, we can use batch processing to query or insert nodes in bulk within a single session and then use the results for the corresponding nodes in the query. That's what this PR does.

This PR also optimizes the Neo4j query syntax, including general syntax improvements and the use of UNWIND to replace Cartesian products. This addresses queries like MATCH (s)-[r]->(t) WHERE s.id IN $source_ids AND t.id IN $target_ids, where the Cartesian product of source_ids and target_ids is generated one by one, causing the query to perform unnecessary matches. Syntax like UNWIND $edge_pairs AS edge MATCH (s)-[r]->(t) WHERE s.id = edge.source_id AND t.id = edge.target_id elegantly fixes the problem.

Additionally, this PR have added the creation of node indexes and other indexes during Neo4j initialization to improve indexing speed. The functionality in the native Networkx has not been changed, only relevant function signatures were added to support batch queries. 

In summary, this PR greatly accelerates the interaction speed between the project and its database through batch queries, optimized syntax, and replacing Cartesian products, while maintaining compatibility with the original code.

I would greatly appreciate it if this PR could be merged.

