### PR TITLE
Make NetworkXStorage.write_nx_graph to asnyc

### DIFF
--- a/nano_graphrag/_storage/gdb_networkx.py
+++ b/nano_graphrag/_storage/gdb_networkx.py
@@ -95,7 +95,14 @@ class NetworkXStorage(BaseGraphStorage):
         }
 
     async def index_done_callback(self):
-        NetworkXStorage.write_nx_graph(self._graph, self._graphml_xml_file)
+        loop = asyncio.get_running_loop()
+        # run the blocking method in the default ThreadPoolExecutor
+        await loop.run_in_executor(
+            None,
+            NetworkXStorage.write_nx_graph,
+            self._graph,
+            self._graphml_xml_file
+        )
 
     async def has_node(self, node_id: str) -> bool:
         return self._graph.has_node(node_id)


### PR DESCRIPTION
index_done_callback is called using asyncio.gather, but the NetworkXStorage.write_nx_graph is not async method, change it to non blocking

passes all the tests in the graph_rag/nano-graphrag/tests/test_networkx_storage.py