### PR TITLE
Fix: Ensure compatibility with Python versions older than 3.12

### DIFF
--- a/nano_graphrag/_op.py
+++ b/nano_graphrag/_op.py
@@ -530,7 +530,7 @@ async def _pack_single_community_describe(
 
     # 4. 准备节点和边数据（过滤子社区已包含的）
     def format_row(row: list) -> str:
-        return ','.join(f'"{str(item).replace("\"", "\"\"")}"' for item in row)
+        return ','.join('"{}"'.format(str(item).replace('"', '""')) for item in row)
 
     node_fields = ["id", "entity", "type", "description", "degree"]
     edge_fields = ["id", "source", "target", "description", "rank"]


### PR DESCRIPTION
The f-string syntax used for CSV row generation is only valid in Python 3.12 and newer. This causes a `SyntaxError` when running the code on earlier versions like Python 3.11.

This commit replaces the incompatible f-string with a `str.format()` call, which is functionally identical and compatible with all supported Python 3 versions.

close #158 