### PR TITLE
fix: add encoding parameter to open() calls in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 import setuptools
 from setuptools import find_packages
 
-with open("readme.md", "r") as fh:
+with open("readme.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 
 vars2find = ["__author__", "__version__", "__url__"]
 vars2readme = {}
-with open("./nano_graphrag/__init__.py") as f:
+with open("./nano_graphrag/__init__.py", encoding="utf-8") as f:
     for line in f.readlines():
         for v in vars2find:
             if line.startswith(v):
@@ -15,7 +15,7 @@ with open("./nano_graphrag/__init__.py") as f:
                 vars2readme[v] = line.split("=")[1]
 
 deps = []
-with open("./requirements.txt") as f:
+with open("./requirements.txt", encoding="utf-8") as f:
     for line in f.readlines():
         if not line.strip():
             continue


### PR DESCRIPTION
## Summary

Add explicit `encoding='utf-8'` parameter to all `open()` calls in `setup.py` to fix installation errors on Windows systems.

## Problem

On Windows, the default file encoding may not be UTF-8 (commonly `cp1252`), causing `'charmap' codec can't decode` errors when installing the package from source.

## Changes

```python
# Before
with open("readme.md", "r") as fh:
with open("./nano_graphrag/__init__.py") as f:
with open("./requirements.txt") as f:

# After
with open("readme.md", "r", encoding="utf-8") as fh:
with open("./nano_graphrag/__init__.py", encoding="utf-8") as f:
with open("./requirements.txt", encoding="utf-8") as f:
```

## Test

- [x] `python setup.py --version` runs successfully
- [x] flake8 checks pass

Closes #140
Closes #163
Closes #125